### PR TITLE
Fix image display issue by correcting CSS class name

### DIFF
--- a/src/components/SignDetails/SignDetails.tsx
+++ b/src/components/SignDetails/SignDetails.tsx
@@ -61,7 +61,7 @@ const SignDetails: React.FC = () => {
                 <div className="letter-image">
                   {currentSign.mediaUrl &&
                     (currentSign.mediaUrl.match(/\.(jpg|jpeg|png|gif)$/i) ? (
-                      <img src={currentSign.mediaUrl} alt={`Sign ${currentSign.word}`} className="letter-media" />
+                      <img src={currentSign.mediaUrl} alt={`Sign ${currentSign.word}`} className="letter-img" />
                     ) : (
                       <video src={currentSign.mediaUrl} controls className="letter-media" autoPlay loop muted>
                         Your browser does not support the video tag.


### PR DESCRIPTION
This PR resolves a problem where the image was not displaying correctly due to the use of the wrong CSS class name. Replacing `letter-media` with `letter-img` fixes the styling so the image now appears as intended.
